### PR TITLE
Remove unnecessary empty array allocation

### DIFF
--- a/core/src/main/scala/basis/collections/immutable/HashTrieMap.scala
+++ b/core/src/main/scala/basis/collections/immutable/HashTrieMap.scala
@@ -122,7 +122,11 @@ final class HashTrieMap[+A, +T] private[collections] (
     else {
       var i = 0
       var j = 0
-      val slots = new Array[AnyRef](newSlotMap.countSetBits + newLeafMap.countSetBits)
+      val size = newSlotMap.countSetBits + newLeafMap.countSetBits
+      if (size == 0) {
+        return HashTrieMap.empty
+      }
+      val slots = new Array[AnyRef](size)
       while (newSlotMap != 0) {
         if ((oldSlotMap & newSlotMap & 1) == 1) slots(j) = this.slots(i)
         if ((oldSlotMap & 1) == 1) i += 1

--- a/core/src/main/scala/basis/collections/immutable/HashTrieSet.scala
+++ b/core/src/main/scala/basis/collections/immutable/HashTrieSet.scala
@@ -100,7 +100,11 @@ final class HashTrieSet[+A] private[collections] (
     else {
       var i = 0
       var j = 0
-      val slots = new Array[AnyRef](newSlotMap.countSetBits)
+      val size = newSlotMap.countSetBits
+      if (size == 0) {
+        return HashTrieSet.empty
+      }
+      val slots = new Array[AnyRef](size)
       while (newSlotMap != 0) {
         if ((oldSlotMap & newSlotMap & 1) == 1) slots(j) = this.slots(i)
         if ((oldSlotMap & 1) == 1) i += 1


### PR DESCRIPTION
When the last key-value pair is removed, an empty HashTrieMap/HashTrieSet should be returned instead of creating a new HashTrieMap/HashTrieSet with an empty array.
